### PR TITLE
Register element with callbacks.tag

### DIFF
--- a/can-custom-elements.js
+++ b/can-custom-elements.js
@@ -32,7 +32,10 @@ function CustomElement(BaseElement) {
 		// but connectedCallback gets called any time the element is inserted
 		// which could be N number of times.
 		if(!this._rendered) {
-			var teardownBindings = exports.setupBindings(this, this._tagData);
+			var tagData = this._tagData || {
+				scope: new Scope()
+			};
+			var teardownBindings = exports.setupBindings(this, tagData);
 
 			// setup our nodeList
 			this._nodeList = nodeLists.register([], teardownBindings, true, false);

--- a/can-custom-elements.js
+++ b/can-custom-elements.js
@@ -1,3 +1,4 @@
+var callbacks = require("can-view-callbacks");
 var domMutate = require("can-util/dom/mutate/mutate");
 var getChildNodes = require("can-util/dom/child-nodes/child-nodes");
 var nodeLists = require("can-view-nodelist");
@@ -7,13 +8,13 @@ function CustomElement(BaseElement) {
 	function CanElement(){
 		var self = Reflect.construct(BaseElement, arguments, this.constructor);
 
-		self._scope = peek(scopeStack);
-
 		self._rendered = false;
 		var Element = self.constructor;
 		if(Element.view) {
 			self.attachShadow({ mode: "open" });
 		}
+
+		setupTagData(self);
 
 		return self;
 	}
@@ -31,11 +32,7 @@ function CustomElement(BaseElement) {
 		// but connectedCallback gets called any time the element is inserted
 		// which could be N number of times.
 		if(!this._rendered) {
-			var tagData = {
-				scope: this._scope || new Scope()
-			};
-
-			var teardownBindings = exports.setupBindings(this, tagData);
+			var teardownBindings = exports.setupBindings(this, this._tagData);
 
 			// setup our nodeList
 			this._nodeList = nodeLists.register([], teardownBindings, true, false);
@@ -43,9 +40,7 @@ function CustomElement(BaseElement) {
 
 			var Element = this.constructor;
 			var scope = new Scope(this);
-			scopeStack.push(scope);
 			var frag = Element.view(scope, null, this._nodeList);
-			scopeStack.pop();
 
 			// Append the resulting document fragment to the element
 			domMutate.appendChild.call(root, frag);
@@ -63,10 +58,17 @@ function CustomElement(BaseElement) {
 	return CanElement;
 }
 
-var scopeStack = [];
+// Register with callbacks.tag so that we can get the tagData
+// associated with this element.
+function setupTagData(el) {
+	var Element = el.constructor;
+	if(!Element._hasSetupTagData) {
+		Element._hasSetupTagData = true;
 
-function peek(arr) {
-	return arr[arr.length - 1];
+		callbacks.tag(el.localName, function(el, tagData){
+			el._tagData = tagData;
+		});
+	}
 }
 
 exports = module.exports = CustomElement;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "can-util": "^3.2.2",
+    "can-view-callbacks": "^3.0.4",
     "can-view-nodelist": "^3.0.4",
     "can-view-scope": "^3.1.2"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -87,7 +87,7 @@ QUnit.test("Can pass data to child components", function(){
 							"content was rendered correctly");
 });
 
-QUnit.skip("Gets data from the passed in scope", function(){
+QUnit.test("Gets data from the passed in scope", function(){
 	var view = stache("{{foo}}");
 
 	var MyComponent = class extends CanElement {


### PR DESCRIPTION
Registering with callbacks.tag allows us to get the element's tagData
which is needed to have the correct scope to render with.

Fixes #7