### PR TITLE
Make both property and DOM events work

### DIFF
--- a/can-custom-elements.js
+++ b/can-custom-elements.js
@@ -1,7 +1,9 @@
 var assign = require("can-util/js/assign/assign");
+var canEvent = require("can-event");
 var domData = require("can-util/dom/data/data");
 var domMutate = require("can-util/dom/mutate/mutate");
 var getChildNodes = require("can-util/dom/child-nodes/child-nodes");
+var GLOBAL = require("can-util/js/global/global");
 var nodeLists = require("can-view-nodelist");
 var Scope = require("can-view-scope");
 
@@ -73,4 +75,21 @@ function CustomElement(BaseElement) {
 
 exports = module.exports = CustomElement;
 
-exports.Element = CustomElement(HTMLElement);
+exports.Element = CustomElement(GLOBAL().HTMLElement);
+
+
+// Wrap canEvent.addEventListener so that we can support both can-defined
+// property events and generic DOM events.
+var addEventListener = canEvent.addEventListener;
+canEvent.addEventListener = function(eventName){
+	var g = GLOBAL();
+	// If this is a custom element without the eventName being a defined property
+	// fallback to DOM events.
+	if((this instanceof g.HTMLElement) && g.customElements.get(this.localName)) {
+		if(this._define && !this._define.definitions[eventName]) {
+			// This is just a regular DOM event.
+			return g.HTMLElement.prototype.addEventListener.apply(this, arguments);
+		}
+	}
+	return addEventListener.apply(this, arguments);
+};

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "canjs"
   ],
   "dependencies": {
+    "can-event": "^3.0.2",
     "can-util": "^3.2.2",
     "can-view-nodelist": "^3.0.4",
     "can-view-scope": "^3.1.2"

--- a/test/es6-test.js
+++ b/test/es6-test.js
@@ -128,7 +128,7 @@ QUnit.test("Gets data from the passed in scope", function(){
 	QUnit.stop();
 });
 
-QUnit.skip("DOM events work when can-defined", function(){
+QUnit.test("DOM events work when can-defined", function(){
 	var view = stache("{{foo}}");
 
 	var EventEl = class extends CanElement {


### PR DESCRIPTION
This fixes #15. Wraps canEvents.addEventListener to fallback to DOM
events if the event isn't for a defined property.