### PR TITLE
Makes the attributes mixin non-global

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Import/require **can-custom-elements** and use the Element to derive your own cl
 
 ```js
 var Element = require("can-custom-elements").Element;
-require("can-custom-elements/attributes");
+var defineAttr = require("can-custom-elements/attributes");
 var define = require("can-define");
 var stache = require("can-stache");
 
@@ -29,6 +29,9 @@ define(HelloWorld.prototype, {
 	}
 });
 
+// Enable the attribute mixin
+defineAttr(HelloWorld);
+
 customElements.define("hello-world", HelloWorld);
 ```
 
@@ -45,7 +48,7 @@ customElements.define("hello-world", HelloWorld);
 
 
 ## <code>__can-custom-elements__ function</code>
-Allows you to create [custom element](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements) classes with CanJS. 
+Allows you to create [custom element](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements) classes with CanJS.
 Safari only supports custom elements that derive from HTMLElement, so you'll usually want to use undefined.
 
 
@@ -73,7 +76,7 @@ customElements.define("super-button", SuperButton);
 
 - __returns__ <code>{[CanElement](#canelement-function)()}</code>:
   A derived element with CanJS behaviors added.
-  
+
 #### CanElement `{function}`
 
 
@@ -85,7 +88,7 @@ An interface for derived elements using either [can-custom-elements](#customelem
 
 
 - __returns__ <code>{undefined}</code>:
-  
+
 ##### CanElement.view `{Object}`
 
 

--- a/test/attributes-test.js
+++ b/test/attributes-test.js
@@ -1,6 +1,6 @@
 var QUnit = require("steal-qunit");
 var CanElement = require("can-custom-elements").Element;
-require("can-custom-elements/attributes");
+var defineAttr = require("can-custom-elements/attributes");
 var compute = require("can-compute");
 var define = require("can-define");
 var stache = require("can-stache");
@@ -32,6 +32,8 @@ QUnit.test("can tag a property as an attribute", function(){
 			type: "string"
 		}
 	});
+
+	defineAttr(AttrEl);
 
 	customElements.define("attr-el", AttrEl);
 
@@ -67,6 +69,8 @@ QUnit.test("Can use 'type' to modify the type on the property", function(){
 		}
 	});
 
+	defineAttr(AttrEl);
+
 	customElements.define("attr-el-2", AttrEl);
 
 	var el = new AttrEl();
@@ -92,6 +96,8 @@ QUnit.test("Properties are observable", function(){
 	define(AttrEl.prototype, {
 		foo: "string"
 	});
+
+	defineAttr(AttrEl);
 
 	customElements.define("attr-el-3", AttrEl);
 


### PR DESCRIPTION
This makes the attributes Define mixin non-global, but instead is called as a function on the constructor.

Closes #21